### PR TITLE
Development

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
+        - name: Dump GitHub context
+          env:
+            GITHUB_CONTEXT: ${{ toJson(github) }}
+          run: echo "$GITHUB_CONTEXT"
         - uses: actions/checkout@v3
         - name: Set up Python
           uses: actions/setup-python@v4
@@ -47,7 +51,7 @@ jobs:
   CD:
     needs: CI
     # Only run this job if new work is pushed to "main"
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.commits[0].author.name != 'semantic-release'
     # Step 1. Set up operating system
     runs-on: ubuntu-latest
     steps:
@@ -67,23 +71,13 @@ jobs:
           pip install python-semantic-release
           git config user.name github-actions
           git config user.email github-actions@github.com
-          semantic-release publish
-#     - name: Publish to TestPyPI
-#       uses: pypa/gh-action-pypi-publish@release/v1
-#       with:
-#         user: __token__
-#         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#         repository_url: https://test.pypi.org/legacy/
-
-#     - name: Test install from TestPyPI
-#       run: |
-#           pip install \
-#           --index-url https://test.pypi.org/simple/ \
-#           --extra-index-url https://pypi.org/simple \
-#           idbsocialdatapy
-
-#     - name: Publish to PyPI
-#       uses: pypa/gh-action-pypi-publish@release/v1
-#       with:
-#         user: __token__
-#         password: ${{ secrets.PYPI_API_TOKEN }}
+          git checkout development
+          semantic-release publish -D branch=development
+    # Step 5. Create new PR
+    - name: Create Pull Request
+      run: |
+           git checkout development
+           TITLE=$(git describe --tags)
+           gh pr create --title $TITLE --body "Automatic version bump" --base main --head development || true
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+      
+jobs:
+  publish:
+    if: github.event.commits[0].author.name == 'semantic-release'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    # Step 1. Check-out repository so we can access its contents
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    # Step 2. Set up Python 3.9
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: python -m pip install --upgrade build
+    - name: Build distribution
+      run: python -m build
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Test install from TestPyPI
+      run: |
+          pip install \
+          --index-url https://test.pypi.org/simple/ \
+          --extra-index-url https://pypi.org/simple \
+          idbsocialdatapy
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
1. Change CD Job within CI/CD workflow to circumvent the main branch protection, so it will push to Development and do a PR to main instead, when a new release is detected. This requires the following permissions to work:

settings->actions->General->Workflow permissions:
- Read and write permissions
- Allow GitHub Actions to create and approve Pull requests

2. Create a separated Publish workflow that is activated when a new push is made and its committer is semantic-release, which only happens when a new release is created. This will allow the possibility to re-run this workflow only in case it fails for whatever reason.